### PR TITLE
added quickstart

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"type": "module",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
-		"dev": "start http://localhost:5173 && vite"
+		"dev": "vite --open",
+		"quickstart": "npm install && npm run dev"
 	},
 	"keywords": [],
 	"author": "",


### PR DESCRIPTION
Issue number #23 
Added the quickstart script under "scripts" that runs npm install and then npm run dev. 
Updated the "dev" script to use vite --open to start the Vite development server and automatically open the default browser.
In devDependencies adding "open": "^8.0.0" is optional, I didn't because it works without it too.